### PR TITLE
Issues/18 href attr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ addons:
     packages:
       - google-chrome-stable
 script:
-  - xvfb-run wct
-  - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct -s 'default'; fi"
+  - xvfb-run wct --skip-plugin sauce
+  - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct --skip-plugin local --plugin sauce; fi"

--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ However, it plays really nice with [Polymer](http://www.polymer-project.org/) [A
 
 ## Browser compatibility
 
-Name       | Support    | Comments
------------|------------|---------
-Chrome 48  | yes        |
-Firefox 43 | yes        |
-IE 11      | partially  | `document._currentScript` behaves wrong in inserted scripts
-Edge 25    | yes        |
-Safari 9   | yes        |
-Safari 8   | not tested |
+Name         | Support    | Comments
+-------------|------------|---------
+Chrome 48    | yes        |
+Firefox 43   | yes        |
+IE 11        | partially  | `document._currentScript` behaves wrong in inserted scripts
+Edge 25      | yes        |
+Safari 10-11 | yes        |
+Safari 9-    | not tested |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 ### External files
 To load HTML from external file all you need is:
 ```html
-<template is="juicy-html" content="./path/to/file.html"></template>
+<template is="juicy-html" href="./path/to/file.html"></template>
 ```
 
 ### Markup provided by attribute
 ```html
-<template is="juicy-html" content="<h1>Hello World</h1>"></template>
+<template is="juicy-html" html="<h1>Hello World</h1>"></template>
 ```
 
 ### Data Binding
@@ -19,7 +19,7 @@ To load HTML from external file all you need is:
 
 ```html
 <template is="juicy-html"
-  content='
+  html='
     All those nodes will get <code>.model</code> property
     with the reference to the object given in model attribute.
     <template is="dom-bind">
@@ -83,30 +83,36 @@ Please note, that loaded `<script>` and `<style>` will be executed every time HT
 	Load HTML partial from a string:
 
 	```html
-	<template is="juicy-html" content="<b>some</b> HTML"></template>
-	<!-- Or <template is="juicy-html" content$="{{var}}"></template> where {{ var }} equals "<b>some</b> HTML" -->
+	<template is="juicy-html" html="<b>some</b> HTML"></template>
+	<!-- Or <template is="juicy-html" html="{{var}}"></template> where {{ var }} equals "<b>some</b> HTML" -->
 	```
 
 	Load HTML partial from a URL:
 
 	```html
-	<template is="juicy-html" content="./path/to/file.html"></template>
-	<!-- Or <template is="juicy-html" content$="{{var}}"></template>
+	<template is="juicy-html" href="./path/to/file.html"></template>
+	<!-- Or <template is="juicy-html" href="{{var}}"></template>
 	     where {{var}} equals "./path/to/file.html", a path relative to the document that must start with / or ./ -->
 	```
 
-## Options/Attributes
+## Attributes
 
 Attribute           | Options         | Default     | Description
 ---                 | ---             | ---         | ---
-`content`           | *string*		  | `""`	    | Safe HTML code, or path (starts with `/`, `./`, or `../`) to partial to be loaded.
+`html`              | *string*		  | `""`	    | Safe HTML code to be stamped.
+`href`              | *string*		  | `""`	    | Path of a partial to be loaded.
 `model`(_optional_) | *Object|String* | `undefined` | Object (or `JSON.stringify`'ied Object) to be attached to every root node of loaded document
 
 ## Properties
 
 Property | Type     | Default     | Description
 ---      | ---      | ---         | ---
-`model`  | *Object* | `undefined` | see above
+`model`  | *Object* | `undefined` | See [attributes](#Attributes)
+`html`   | *string* | `""`	      | See [attributes](#Attributes)
+`href`   | *string* | `""`	      | See [attributes](#Attributes)
+
+Please note, that properties are available after element is upgraded.
+To provide a state before element is upgraded, please use attributes.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Please note, that loaded `<script>` and `<style>` will be executed every time HT
 
 Attribute           | Options         | Default     | Description
 ---                 | ---             | ---         | ---
-`html`              | *string*		  | `""`	    | Safe HTML code to be stamped.
-`href`              | *string*		  | `""`	    | Path of a partial to be loaded.
+`html`              | *string*		  | `""`	    | Safe HTML code to be stamped. Setting this one will skip any pending request for `href` and remove `href` attribute.
+`href`              | *string*		  | `""`	    | Path of a partial to be loaded. Setting this one will remove `html` attribute.
 `model`(_optional_) | *Object|String* | `undefined` | Object (or `JSON.stringify`'ied Object) to be attached to every root node of loaded document
 
 ## Properties

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "juicy-html",
   "description": "Custom Element that lets you load HTML partials into your Web Components",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "homepage": "https://github.com/Juicy/juicy-html",
   "authors": [
     "Joachim Wester <joachimwester@me.com>",

--- a/examples/basic_file.html
+++ b/examples/basic_file.html
@@ -15,8 +15,8 @@
     </style>
 </head>
 <body class="markdown-body">
-    <template is="juicy-html" content="./partials/basic.html"></template>
+    <template is="juicy-html" href="./partials/basic.html"></template>
     <h2>code</h2>
-<pre><code>&lt;template is="juicy-html" content="./partials/basic.html"&gt;&lt;/template&gt;</code></pre>
+<pre><code>&lt;template is="juicy-html" href="./partials/basic.html"&gt;&lt;/template&gt;</code></pre>
 </body>
 </html>

--- a/examples/basic_inline.html
+++ b/examples/basic_inline.html
@@ -15,8 +15,8 @@
     </style>
 </head>
 <body class="markdown-body">
-    <template is="juicy-html" content="<h1>Hello World!</h1> <p>I'm <strong>inline</strong> content.</p>"></template>
+    <template is="juicy-html" href="<h1>Hello World!</h1> <p>I'm <strong>inline</strong> content.</p>"></template>
     <h2>code</h2>
-    <pre><code>&lt;template is="juicy-html" content="&lt;h1&gt;Hello World!&lt;/h1&gt; &lt;p&gt;I'm &lt;strong&gt;inline&lt;/strong&gt; content.&lt;/p&gt;"&gt;&lt;/template&gt;</code></pre>
+    <pre><code>&lt;template is="juicy-html" href="&lt;h1&gt;Hello World!&lt;/h1&gt; &lt;p&gt;I'm &lt;strong&gt;inline&lt;/strong&gt; content.&lt;/p&gt;"&gt;&lt;/template&gt;</code></pre>
 </body>
 </html>

--- a/examples/components/my-app.html
+++ b/examples/components/my-app.html
@@ -18,7 +18,7 @@
                 width: 300px;
             }
         </style>
-        <template is="juicy-html" content$="{{viewmodel.html}}" model="{{viewmodel}}" on-stamped="stamped"></template>
+        <template is="juicy-html" href="{{viewmodel.html}}" model="{{viewmodel}}" on-stamped="stamped"></template>
     </template>
 </dom-module>
 <script>

--- a/examples/polymer_template_inline.html
+++ b/examples/polymer_template_inline.html
@@ -25,7 +25,7 @@
 <body class="markdown-body">
     <template id="test" is="dom-bind">
         <h1>Fancy inline partial within Polymer's dom-bind</h1>
-        <template is="juicy-html" content$="{{model.subpage.Html}}" model="{{model.subpage}}">
+        <template is="juicy-html" href="{{model.subpage.Html}}" model="{{model.subpage}}">
         </template>
         <h3>Code (live)</h3>
         <textarea value="{{model.subpage.Html::input}}"></textarea>

--- a/examples/polymer_template_partial.html
+++ b/examples/polymer_template_partial.html
@@ -17,7 +17,7 @@
 </head>
 <body>
     <template id="test" is="dom-bind">
-        <template model="{{model.subpage}}" is="juicy-html" content$="{{model.subpage.html}}"></template>
+        <template model="{{model.subpage}}" is="juicy-html" href="{{model.subpage.html}}"></template>
     </template>
     <script>
         var model = {

--- a/examples/template_partial_sibling.html
+++ b/examples/template_partial_sibling.html
@@ -19,7 +19,7 @@
     <h2>Hey! those are siblings:</h2>
     <ul>
         <li class="specialExternal">Just plain <code>&lt;li&gt;</code></li>
-        <template is="juicy-html" content="./partials/page_4.html"></template>
+        <template is="juicy-html" href="./partials/page_4.html"></template>
     </ul>
 </body>
 </html>

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -68,13 +68,13 @@ version: 1.2.0
                 'html': {
                     set: function(newValue) {
                         if(newValue === null){
-                            this.removeAttribute('href');
+                            this.removeAttribute('html');
                         } else {
-                            this.setAttribute('href', newValue);
+                            this.setAttribute('html', newValue);
                         }
                     },
                     get: function() {
-                        return this.getAttribute('href');
+                        return this.getAttribute('html');
                     }
                 }
             });

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -8,17 +8,41 @@ version: 1.2.0
 <script>
     (function(scope) {
         /**
-         * Thor a warning to the console about deprecated content attribute
+         * Throw a warning to the console about deprecated content attribute
          * @param  {JuicyHTMLElement} element reference to the element
          */
         function warnAboutDeprecatedContentOn(element){
-            console.warn('`content` attribute is deprecated! Please, use `href` instead.', element);
+            console.warn(
+                '`content` attribute is deprecated! Please, use `href` or `html` instead.',
+                element,
+                'We will drop support for it in next release.'
+            );
         }
+        /**
+         * Translate content tag changes to href and html attributes
+         * @param {JuicyHTMLElement} element to set attibutes on
+         * @param {String} value value of content attr
+         */
+        function forwardContentValue(element, value){
+            if (value && (value.indexOf('/') === 0 || value.indexOf('./') === 0 || value.indexOf('../') === 0)) {
+                //value is a URL, load the partial from external file
+                element.removeAttribute('html');
+                element.setAttribute('href', value);
+            } else if (value === null) {
+                element.removeAttribute('html');
+                element.removeAttribute('href');
+            } else {
+                //value is HTML code, insert the partial from the string
+                element.removeAttribute('href');
+                element.setAttribute('html', value);
+            }
+        }
+
         var JuicyHTMLPrototype = Object.create((HTMLTemplateElement || HTMLElement).prototype);
         var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
 
         JuicyHTMLPrototype.createdCallback = function() {
-            var model = null;
+            var model = null; // XXX(tomalec): || this.model ?
             Object.defineProperties(this, {
                 'model': {
                     set: function(newValue) {
@@ -40,6 +64,18 @@ version: 1.2.0
                     get: function() {
                         return this.getAttribute('href');
                     }
+                },
+                'html': {
+                    set: function(newValue) {
+                        if(newValue === null){
+                            this.removeAttribute('href');
+                        } else {
+                            this.setAttribute('href', newValue);
+                        }
+                    },
+                    get: function() {
+                        return this.getAttribute('href');
+                    }
                 }
             });
         };
@@ -50,20 +86,6 @@ version: 1.2.0
         JuicyHTMLPrototype.pending = null;
 
         JuicyHTMLPrototype.stampedNodes = null;
-        JuicyHTMLPrototype.loadTemplate_ = function() {
-            // skip pending request
-            this.skipStampingPendingFile();
-            var val = this.getAttribute('href');
-            if (val && (val.indexOf('/') === 0 || val.indexOf('./') === 0 || val.indexOf('../') === 0)) {
-                //val is a URL, load the partial from external file
-                this._loadExternalFile(val);
-            } else if (val === null) {
-                this.clear();
-            } else {
-                //val is HTML code, insert the partial from the string
-                this.reattachTemplate_(val);
-            }
-        };
         /**
          * Skips/disregards pending request if any.
          */
@@ -138,13 +160,17 @@ version: 1.2.0
 
         JuicyHTMLPrototype.isAttached = false;
         JuicyHTMLPrototype.attachedCallback = function() {
-            // translate legacy `content` attribute to href
+            this.isAttached = true;
+            // autostamp
+            // translate legacy `content` attribute
             if(this.hasAttribute('content')){
                 warnAboutDeprecatedContentOn(this);
-                this.setAttribute('href', this.getAttribute('content'));
+                forwardContentValue(this, this.getAttribute('content'));
+            } else {
+                // TODO(tomalec): read pre-upgrade properties in cheap manner
+                this.hasAttribute('href') && this.attributeChangedCallback('href', null, this.getAttribute('href'));
+                this.hasAttribute('html') && this.attributeChangedCallback('html', null, this.getAttribute('html'));
             }
-            this.isAttached = true;
-            this.loadTemplate_();
         };
         JuicyHTMLPrototype.detachedCallback = function() {
             this.isAttached = false;
@@ -161,14 +187,25 @@ version: 1.2.0
                         break;
                     case "content":
                         warnAboutDeprecatedContentOn(this);
-                        if(newVal === null){
-                            this.removeAttribute('href');
-                        } else {
-                            this.setAttribute('href', newVal);
-                        }
+                        forwardContentValue(this, newVal);
                         break;
                     case "href":
-                        this.loadTemplate_();
+                        // skip pending request
+                        this.skipStampingPendingFile();
+                        if(newVal !== null){
+                            this.removeAttribute('html');
+                            this._loadExternalFile(newVal);
+                        } else {
+                            this.clear();
+                        }
+                        break;
+                    case "html":
+                        if(newVal !== null){
+                            this.removeAttribute('href');
+                            this.reattachTemplate_(newVal);
+                        } else {
+                            this.clear();
+                        }
                         break;
                 }
             }

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -3,7 +3,7 @@ juicy-html.html
 (c) 2013-2015 Juicy
 MIT license
 https://github.com/Juicy/juicy-html
-version: 1.1.0
+version: 1.2.0
 -->
 <script>
     (function(scope) {

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -7,18 +7,39 @@ version: 1.2.0
 -->
 <script>
     (function(scope) {
+        /**
+         * Thor a warning to the console about deprecated content attribute
+         * @param  {JuicyHTMLElement} element reference to the element
+         */
+        function warnAboutDeprecatedContentOn(element){
+            console.warn('`content` attribute is deprecated! Please, use `href` instead.', element);
+        }
         var JuicyHTMLPrototype = Object.create((HTMLTemplateElement || HTMLElement).prototype);
         var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
 
         JuicyHTMLPrototype.createdCallback = function() {
             var model = null;
-            Object.defineProperty(this, "model", {
-                set: function(newValue) {
-                    model = newValue;
-                    this.attachModel(newValue);
+            Object.defineProperties(this, {
+                'model': {
+                    set: function(newValue) {
+                        model = newValue;
+                        this.attachModel(newValue);
+                    },
+                    get: function() {
+                        return model;
+                    }
                 },
-                get: function() {
-                    return model;
+                'href': {
+                    set: function(newValue) {
+                        if(newValue === null){
+                            this.removeAttribute('href');
+                        } else {
+                            this.setAttribute('href', newValue);
+                        }
+                    },
+                    get: function() {
+                        return this.getAttribute('href');
+                    }
                 }
             });
         };
@@ -32,7 +53,7 @@ version: 1.2.0
         JuicyHTMLPrototype.loadTemplate_ = function() {
             // skip pending request
             this.skipStampingPendingFile();
-            var val = this.getAttribute('content');
+            var val = this.getAttribute('href');
             if (val && (val.indexOf('/') === 0 || val.indexOf('./') === 0 || val.indexOf('../') === 0)) {
                 //val is a URL, load the partial from external file
                 this._loadExternalFile(val);
@@ -72,9 +93,9 @@ version: 1.2.0
             this.clear();
             if(html === ''){
                 if(statusCode === 204){
-                    console.info('no content was returned for juicy-html (', this, ')');
+                    console.info('no content was returned for juicy-html', this);
                 } else {
-                    console.warn('content given for juicy-html (', this, ') is an empty file');
+                    console.warn('content given for juicy-html is an empty file', this);
                 }
             }
             // fragmentFromString(strHTML) from http://stackoverflow.com/a/25214113/868184
@@ -117,6 +138,11 @@ version: 1.2.0
 
         JuicyHTMLPrototype.isAttached = false;
         JuicyHTMLPrototype.attachedCallback = function() {
+            // translate legacy `content` attribute to href
+            if(this.hasAttribute('content')){
+                warnAboutDeprecatedContentOn(this);
+                this.setAttribute('href', this.getAttribute('content'));
+            }
             this.isAttached = true;
             this.loadTemplate_();
         };
@@ -134,6 +160,14 @@ version: 1.2.0
                         this.model = newVal;
                         break;
                     case "content":
+                        warnAboutDeprecatedContentOn(this);
+                        if(newVal === null){
+                            this.removeAttribute('href');
+                        } else {
+                            this.setAttribute('href', newVal);
+                        }
+                        break;
+                    case "href":
                         this.loadTemplate_();
                         break;
                 }

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -42,7 +42,7 @@ version: 1.2.0
         var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
 
         JuicyHTMLPrototype.createdCallback = function() {
-            var model = null; // XXX(tomalec): || this.model ?
+            var model = null; // XXX(tomalec): || this.model ? // to consider for https://github.com/Juicy/juicy-html/issues/30
             Object.defineProperties(this, {
                 'model': {
                     set: function(newValue) {
@@ -162,15 +162,11 @@ version: 1.2.0
         JuicyHTMLPrototype.attachedCallback = function() {
             this.isAttached = true;
             // autostamp
+            // TODO(tomalec): read pre-upgrade properties in cheap manner
+            this.hasAttribute('href') && this.attributeChangedCallback('href', null, this.getAttribute('href'));
+            this.hasAttribute('html') && this.attributeChangedCallback('html', null, this.getAttribute('html'));
             // translate legacy `content` attribute
-            if(this.hasAttribute('content')){
-                warnAboutDeprecatedContentOn(this);
-                forwardContentValue(this, this.getAttribute('content'));
-            } else {
-                // TODO(tomalec): read pre-upgrade properties in cheap manner
-                this.hasAttribute('href') && this.attributeChangedCallback('href', null, this.getAttribute('href'));
-                this.hasAttribute('html') && this.attributeChangedCallback('html', null, this.getAttribute('html'));
-            }
+            this.hasAttribute('content') && this.attributeChangedCallback('content', null, this.getAttribute('content'));
         };
         JuicyHTMLPrototype.detachedCallback = function() {
             this.isAttached = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juicy-html",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "`<juicy-html>` is a custom element that let's you load HTML partials into your Web Components",
   "homepage": "https://github.com/Juicy/juicy-html",
   "repository": {

--- a/test/content-legacy/deprecation-warning.html
+++ b/test/content-legacy/deprecation-warning.html
@@ -1,0 +1,88 @@
+﻿<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+
+    <!-- Step 1: import the element to test -->
+    <link rel="import" href="../../juicy-html.html">
+</head>
+
+<body>
+
+    <test-fixture id="juicy-html-with-content">
+        <template>
+            <!-- nest to workaround test-fixture bug -->
+            <div><template is="juicy-html" content="/mock/smth">
+            </template></div>
+        </template>
+    </test-fixture>
+    <test-fixture id="juicy-html-without-content">
+        <template>
+            <!-- nest to workaround test-fixture bug -->
+            <div><template is="juicy-html">
+            </template></div>
+        </template>
+    </test-fixture>
+
+    <script>
+        describe('<juicy-html>', function () {
+            var myEl, changedEl, server, infoSpy, warnSpy, errorSpy;
+            beforeEach(function () {
+                infoSpy = sinon.spy(console, 'info');
+                infoSpy.displayName = 'console.info';
+                warnSpy = sinon.spy(console, 'warn');
+                warnSpy.displayName = 'console.warn';
+                errorSpy = sinon.spy(console, 'error');
+                errorSpy.displayName = 'console.error';
+            });
+            afterEach(function () {
+                infoSpy.restore();
+                warnSpy.restore();
+                errorSpy.restore();
+            });
+            before(function () {
+                var server = sinon.fakeServer.create();
+                server.xhr.useFilters = true;
+                server.xhr.addFilter(function (method, url) {
+                    //whenever the this returns true the request will not faked
+                    return !url.match(/mock\//);
+                });
+                server.respondWith('GET', '/mock/smth', [200, {"Content-Type": "text/html"}, '<div id="smth">smth</div>']);
+                server.autoRespond = true;
+            });
+            context('when element is attached with content attribute', function () {
+                beforeEach(function (done) {
+                    myEl = fixture('juicy-html-with-content').querySelector('template[is="juicy-html"]');
+                    // wait for (faked) XHR
+                    setTimeout(done, 100);
+                });
+
+                it('should call <code>console.warn</code> with message about "deprecate" and "href"', function () {
+                    expect(warnSpy.withArgs(sinon.match(/deprecate.*href/))).to.be.calledOnce;
+                });
+
+            });
+            context('when content attribute is changed', function () {
+                beforeEach(function (done) {
+                    myEl = fixture('juicy-html-without-content').querySelector('template[is="juicy-html"]');
+                    myEl.setAttribute('content', '/mock/smth');
+                    // wait for (faked) XHR
+                    setTimeout(done, 100);
+                });
+
+                it('should call <code>console.warn</code> with message about "deprecate" and "href"', function () {
+                    expect(warnSpy.withArgs(sinon.match(/deprecate.*href/))).to.be.calledOnce;
+                });
+
+            });
+        });
+    </script>
+
+</body>
+
+</html>

--- a/test/content-legacy/deprecation-warning.html
+++ b/test/content-legacy/deprecation-warning.html
@@ -62,8 +62,8 @@
                     setTimeout(done, 100);
                 });
 
-                it('should call <code>console.warn</code> with message about "deprecate" and "href"', function () {
-                    expect(warnSpy.withArgs(sinon.match(/deprecate.*href/))).to.be.calledOnce;
+                it('should call <code>console.warn</code> with message about "deprecate", "href" and "html"', function () {
+                    expect(warnSpy.withArgs(sinon.match(/deprecate.*href.*html/))).to.be.calledOnce;
                 });
 
             });
@@ -75,8 +75,8 @@
                     setTimeout(done, 100);
                 });
 
-                it('should call <code>console.warn</code> with message about "deprecate" and "href"', function () {
-                    expect(warnSpy.withArgs(sinon.match(/deprecate.*href/))).to.be.calledOnce;
+                it('should call <code>console.warn</code> with message about "deprecate", "href" and "html"', function () {
+                    expect(warnSpy.withArgs(sinon.match(/deprecate.*href.*html/))).to.be.calledOnce;
                 });
 
             });

--- a/test/content-legacy/inline.html
+++ b/test/content-legacy/inline.html
@@ -5,11 +5,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
-    <link rel="import" href="../juicy-html.html">
+    <link rel="import" href="../../juicy-html.html">
 </head>
 
 <body>
@@ -18,7 +18,7 @@
     <test-fixture id="juicy-html-fixture">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="<h1>Hello World</h1>">
+            <div><template is="juicy-html" content="<h1>Hello World</h1>">
             </template></div>
         </template>
     </test-fixture>
@@ -26,7 +26,7 @@
     <script>
         describe('<juicy-html>', function() {
             var myEl;
-            context('when created with HTML markup in href attribute', function() {
+            context('when created with HTML markup in content attribute', function() {
                 beforeEach(function() {
                     myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
                 });
@@ -36,14 +36,14 @@
                     expect(myEl.nextElementSibling.innerHTML).to.equal('Hello World');
                 });
 
-                it('should remove stamped nodes after href is cleared', function(){
-                    myEl.setAttribute('href', null);
+                it('should remove stamped nodes after content is cleared', function(){
+                    myEl.setAttribute('content', null);
                     expect(myEl.nextElementSibling).to.be.null;
                     expect(myEl.previousElementSibling).to.be.null;
                 });
 
                 it('after markup is changed, should re-stamp it into DOM as a sibling', function(){
-                    myEl.setAttribute('href', '<h2>new content</h2>');
+                    myEl.setAttribute('content', '<h2>new content</h2>');
                     expect(myEl.nextElementSibling).to.be.not.null;
                     expect(myEl.nextElementSibling.tagName).to.equal('H2');
                     expect(myEl.nextElementSibling.innerHTML).to.equal('new content');
@@ -61,9 +61,9 @@
                 });
 
                 // https://github.com/Juicy/juicy-html/issues/17
-                it('should remove stamped nodes after `href` attribute is removed', function(){
+                it('should remove stamped nodes after `content` attribute is removed', function(){
                     var parent = myEl.parentNode;
-                    myEl.removeAttribute('href');
+                    myEl.removeAttribute('content');
                     expect(parent.children.length).to.be.equal(1);
                     expect(parent.childNodes.length).to.be.equal(1);
                 });

--- a/test/content-legacy/no-content.html
+++ b/test/content-legacy/no-content.html
@@ -5,33 +5,33 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
-    <link rel="import" href="../juicy-html.html">
+    <link rel="import" href="../../juicy-html.html">
 </head>
 
 <body>
 
-    <test-fixture id="juicy-html-with-href">
+    <test-fixture id="juicy-html-with-content">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="/mock/smth">
+            <div><template is="juicy-html" content="/mock/smth">
             </template></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-204-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="/mock/204">
+            <div><template is="juicy-html" content="/mock/204">
             </template></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-200-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="/mock/200">
+            <div><template is="juicy-html" content="/mock/200">
             </template></div>
         </template>
     </test-fixture>
@@ -68,8 +68,8 @@
                 beforeEach(function (done) {
 
                     myEl = fixture('juicy-html-204-empty').querySelector('template[is="juicy-html"]');
-                    changedEl = fixture('juicy-html-with-href').querySelector('template[is="juicy-html"]');
-                    changedEl.setAttribute('href', '/mock/204');
+                    changedEl = fixture('juicy-html-with-content').querySelector('template[is="juicy-html"]');
+                    changedEl.setAttribute('content', '/mock/204');
                     // wait for (faked) XHR
                     setTimeout(done, 100);
                 });
@@ -90,8 +90,8 @@
             context('when external file returns <code>200 Ok</code> but no content', function () {
                 beforeEach(function (done) {
                     myEl = fixture('juicy-html-200-empty').querySelector('template[is="juicy-html"]');
-                    changedEl = fixture('juicy-html-with-href').querySelector('template[is="juicy-html"]');
-                    changedEl.setAttribute('href', '/mock/200');
+                    changedEl = fixture('juicy-html-with-content').querySelector('template[is="juicy-html"]');
+                    changedEl.setAttribute('content', '/mock/200');
                     // wait for (faked) XHR
                     setTimeout(done, 100);
                 });
@@ -103,9 +103,9 @@
                     expect(changedEl.nextElementSibling).to.be.null;
                     expect(changedEl.previousElementSibling).to.be.null;
                 });
-                it('should call <code>console.warn</code>', function () {
-                    expect(warnSpy).to.be.called;
-                    expect(warnSpy).to.be.calledTwice; // once per element
+                it('should call <code>console.warn</code> with message about "empty"', function () {
+                    expect(warnSpy.withArgs(sinon.match(/empty/))).to.be.called;
+                    expect(warnSpy.withArgs(sinon.match(/empty/))).to.be.calledTwice; // once per element
                 });
 
             });

--- a/test/content-legacy/skipping.html
+++ b/test/content-legacy/skipping.html
@@ -5,11 +5,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
-    <link rel="import" href="../juicy-html.html">
+    <link rel="import" href="../../juicy-html.html">
 </head>
 
 <body>
@@ -29,7 +29,7 @@
             context('when skipStampingPendingFile method is called after request for file was send but before it responded', function() {
                 beforeEach(function() {
                     myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
-                    myEl.setAttribute('href', '../partials/basic.html');
+                    myEl.setAttribute('content', '../../partials/basic.html');
                     myEl.skipStampingPendingFile();
                 });
                 it('should NOT stamp anything', function(done){
@@ -40,22 +40,22 @@
                     }, 300);
                 });
             });
-            context('when href property is changed', function() {
+            context('when content property is changed', function() {
                 beforeEach(function() {
                     myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
-                    myEl.setAttribute('href', '../partials/basic.html');
+                    myEl.setAttribute('content', '../../partials/basic.html');
                     sinon.spy(myEl, 'skipStampingPendingFile');
                 });
                 it('to another url, skipStampingPendingFile method should get called', function(){
-                    myEl.setAttribute('href', '../partials/page_1.html');
+                    myEl.setAttribute('content', '../../partials/page_1.html');
                     expect(myEl.skipStampingPendingFile).to.be.calledOnce;
                 });
                 it('to a string, skipStampingPendingFile method should get called', function(){
-                    myEl.setAttribute('href', 'blah');
+                    myEl.setAttribute('content', 'blah');
                     expect(myEl.skipStampingPendingFile).to.be.calledOnce;
                 });
                 it('to `null`, skipStampingPendingFile method should get called', function(){
-                    myEl.setAttribute('href', null);
+                    myEl.setAttribute('content', null);
                     expect(myEl.skipStampingPendingFile).to.be.calledOnce;
                 });
             });

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,10 @@
     <script>
         // Load and run all tests (.html, .js):
         WCT.loadSuites([
+          'content-legacy/inline.html',
+          'content-legacy/no-content.html',
+          'content-legacy/skipping.html',
+          'content-legacy/deprecation-warning.html',
           'inline.html',
           'no-content.html',
           'skipping.html'

--- a/test/inline.html
+++ b/test/inline.html
@@ -18,7 +18,7 @@
     <test-fixture id="juicy-html-fixture">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="<h1>Hello World</h1>">
+            <div><template is="juicy-html" html="<h1>Hello World</h1>">
             </template></div>
         </template>
     </test-fixture>
@@ -26,7 +26,7 @@
     <script>
         describe('<juicy-html>', function() {
             var myEl;
-            context('when created with HTML markup in href attribute', function() {
+            context('when created with HTML markup in html attribute', function() {
                 beforeEach(function(done) {
                     myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
                     // wait for polyfilled callbacks
@@ -38,14 +38,14 @@
                     expect(myEl.nextElementSibling.innerHTML).to.equal('Hello World');
                 });
 
-                it('should remove stamped nodes after href is cleared', function(){
-                    myEl.setAttribute('href', null);
+                it('should remove stamped nodes after html is cleared', function(){
+                    myEl.setAttribute('html', null);
                     expect(myEl.nextElementSibling).to.be.null;
                     expect(myEl.previousElementSibling).to.be.null;
                 });
 
                 it('after markup is changed, should re-stamp it into DOM as a sibling', function(){
-                    myEl.setAttribute('href', '<h2>new content</h2>');
+                    myEl.setAttribute('html', '<h2>new content</h2>');
                     expect(myEl.nextElementSibling).to.be.not.null;
                     expect(myEl.nextElementSibling.tagName).to.equal('H2');
                     expect(myEl.nextElementSibling.innerHTML).to.equal('new content');
@@ -63,9 +63,9 @@
                 });
 
                 // https://github.com/Juicy/juicy-html/issues/17
-                it('should remove stamped nodes after `href` attribute is removed', function(){
+                it('should remove stamped nodes after `html` attribute is removed', function(){
                     var parent = myEl.parentNode;
-                    myEl.removeAttribute('href');
+                    myEl.removeAttribute('html');
                     expect(parent.children.length).to.be.equal(1);
                     expect(parent.childNodes.length).to.be.equal(1);
                 });

--- a/test/skipping.html
+++ b/test/skipping.html
@@ -24,12 +24,15 @@
     </test-fixture>
 
     <script>
-        describe('<juicy-html>', function() {
+        describe('<juicy-html> after request for file was send but before it responded', function() {
             var myEl;
-            context('when skipStampingPendingFile method is called after request for file was send but before it responded', function() {
+            beforeEach(function() {
+                myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
+                myEl.setAttribute('href', '../examples/partials/basic.html');
+                sinon.spy(myEl, 'skipStampingPendingFile');
+            });
+            context('when skipStampingPendingFile method is called', function() {
                 beforeEach(function() {
-                    myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
-                    myEl.setAttribute('href', '../partials/basic.html');
                     myEl.skipStampingPendingFile();
                 });
                 it('should NOT stamp anything', function(done){
@@ -40,23 +43,47 @@
                     }, 300);
                 });
             });
-            context('when href property is changed', function() {
-                beforeEach(function() {
-                    myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
-                    myEl.setAttribute('href', '../partials/basic.html');
-                    sinon.spy(myEl, 'skipStampingPendingFile');
-                });
+            context('when href attribute is changed', function() {
                 it('to another url, skipStampingPendingFile method should get called', function(){
-                    myEl.setAttribute('href', '../partials/page_1.html');
+                    myEl.setAttribute('href', '../examples/partials/page_1.html');
                     expect(myEl.skipStampingPendingFile).to.be.calledOnce;
                 });
-                it('to a string, skipStampingPendingFile method should get called', function(){
-                    myEl.setAttribute('href', 'blah');
+                it('- removed, skipStampingPendingFile method should get called', function(){
+                    myEl.removeAttribute('href');
+                    expect(myEl.skipStampingPendingFile).to.be.calledOnce;
+                });
+            });
+            context('when href property is changed', function() {
+                it('to another url, skipStampingPendingFile method should get called', function(){
+                    myEl.href = '../examples/partials/page_1.html';
                     expect(myEl.skipStampingPendingFile).to.be.calledOnce;
                 });
                 it('to `null`, skipStampingPendingFile method should get called', function(){
-                    myEl.setAttribute('href', null);
+                    myEl.href = null;
                     expect(myEl.skipStampingPendingFile).to.be.calledOnce;
+                });
+            });
+            context('when html attribute is changed', function() {
+                it('to a string, skipStampingPendingFile method should get called', function(){
+                    myEl.setAttribute('html', 'blah');
+                    expect(myEl.skipStampingPendingFile).to.be.calledOnce;
+                });
+                it('- removed, skipStampingPendingFile method should NOT get called', function(done){
+                    myEl.removeAttribute('html');
+                    setTimeout(function waitForCall(){
+                        expect(myEl.skipStampingPendingFile).not.to.be.called;
+                        done();
+                    }, 200);
+                });
+            });
+            context('when html property is changed', function() {
+                it('to a string, skipStampingPendingFile method should get called', function(){
+                    myEl.html = 'blah';
+                    expect(myEl.skipStampingPendingFile).to.be.calledOnce;
+                });
+                it('to `null`, skipStampingPendingFile method should NOT get called', function(){
+                    myEl.html = null;
+                    expect(myEl.skipStampingPendingFile).not.to.be.called;
                 });
             });
         });

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,24 @@
+{
+    "verbose": false,
+    "plugins": {
+        "local": {
+            "browsers": ["chrome", "firefox"]
+        },
+        "sauce": {
+            "disabled": true,
+            "browsers": [{
+                "browserName": "microsoftedge",
+                "platform": "Windows 10",
+                "version": ""
+            }, {
+                "browserName": "internet explorer",
+                "platform": "Windows 8.1",
+                "version": "11"
+            }, {
+                "browserName": "safari",
+                "platform": "OS X 10.11",
+                "version": "10"
+            }]
+        }
+    }
+}

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -18,10 +18,6 @@
                 "browserName": "safari",
                 "platform": "OS X 10.11",
                 "version": "10"
-            }, {
-                "browserName": "safari",
-                "platform": "OS X 10.11",
-                "version": "11"
             }]
         }
     }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -18,6 +18,10 @@
                 "browserName": "safari",
                 "platform": "OS X 10.11",
                 "version": "10"
+            }, {
+                "browserName": "safari",
+                "platform": "OS X 10.11",
+                "version": "11"
             }]
         }
     }


### PR DESCRIPTION
Add `href` and `html` attributes and property setters as proposed at https://github.com/Juicy/juicy-html/issues/18#issuecomment-320338863 with backward compatibility layer and warning for old `content` attr.

Please note that this is not the end of the story, once we release this in CE V0 with new minor/major I'd  start a new major written in CE v1 only (to be run in V0 using polyfill like `document-register-element`)

//cc @warpech @alshakero 