### PR TITLE
Make it autonomous CEv1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,27 @@
 ### External files
 To load HTML from external file all you need is:
 ```html
-<template is="juicy-html" href="./path/to/file.html"></template>
+<juicy-html href="./path/to/file.html"></juicy-html>
 ```
 
 ### Markup provided by attribute
 ```html
-<template is="juicy-html" html="<h1>Hello World</h1>"></template>
+<juicy-html html="<h1>Hello World</h1>"></juicy-html>
 ```
 
 ### Data Binding
 `juicy-html` may forward given model object to stamped elements.
 
 ```html
-<template is="juicy-html"
+<juicy-html
   html='
     All those nodes will get <code>.model</code> property
     with the reference to the object given in model attribute.
-    <template is="dom-bind">
-      <p>which can be used by <span>{{model.polymer}}</span></p>
-    </template>
+    <dom-bind>
+      <template is="dom-bind">
+        <p>which can be used by <span>{{model.polymer}}</span></p>
+      </template>
+    </dom-bind>
     <custom-element>that uses `.model` property<custom-element>
     <script>
       // script that may use
@@ -34,7 +36,7 @@ To load HTML from external file all you need is:
   model='{
     "polymer": "Polymer&apos;s dom-bind",
     "vanilla": "as well as by native JS <code>&amp;lt;script&amp;gt;</code> or custom elements"
-   }'>
+  }'></juicy-html>
 ```
 HTML may naturally be provided from external file, and `model` can be provided using Polymer's/or any other data-binding as real object (not a string)
 
@@ -70,7 +72,7 @@ Please note, that loaded `<script>` and `<style>` will be executed every time HT
 1. Import Web Components' polyfill (if needed):
 
     ```html
-    <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+    <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
     ```
 
 2. Import Custom Element:
@@ -84,15 +86,15 @@ Please note, that loaded `<script>` and `<style>` will be executed every time HT
 	Load HTML partial from a string:
 
 	```html
-	<template is="juicy-html" html="<b>some</b> HTML"></template>
-	<!-- Or <template is="juicy-html" html="{{var}}"></template> where {{ var }} equals "<b>some</b> HTML" -->
+	<juicy-html html="<b>some</b> HTML"></juicy-html>
+	<!-- Or <juicy-html html="{{var}}"></juicy-html> where {{ var }} equals "<b>some</b> HTML" -->
 	```
 
 	Load HTML partial from a URL:
 
 	```html
-	<template is="juicy-html" href="./path/to/file.html"></template>
-	<!-- Or <template is="juicy-html" href="{{var}}"></template>
+	<juicy-html href="./path/to/file.html"></juicy-html>
+	<!-- Or <juicy-html href="{{var}}"></juicy-html>
 	     where {{var}} equals "./path/to/file.html", a path relative to the document that must start with / or ./ -->
 	```
 

--- a/bower.json
+++ b/bower.json
@@ -28,8 +28,8 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "polymer": "^1.9.1",
+    "polymer": "^2.0.0",
     "web-component-tester": "^6.0.0",
-    "webcomponentsjs": "^0.7.24"
+    "webcomponentsjs": "^1.0.0"
   }
 }

--- a/examples/basic_file.html
+++ b/examples/basic_file.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>&lt;juicy-html&gt; basic partial from file</title>
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="stylesheet" href="//juicy.github.io/juicy-tile-list/examples/github-markdown.css">
     <link rel="import" href="../juicy-html.html">
     <style>
@@ -15,8 +15,8 @@
     </style>
 </head>
 <body class="markdown-body">
-    <template is="juicy-html" href="./partials/basic.html"></template>
+    <juicy-html href="./partials/basic.html"></juicy-html>
     <h2>code</h2>
-<pre><code>&lt;template is="juicy-html" href="./partials/basic.html"&gt;&lt;/template&gt;</code></pre>
+<pre><code>&lt;juicy-html href="./partials/basic.html"&gt;&lt;/juicy-html&gt;</code></pre>
 </body>
 </html>

--- a/examples/basic_inline.html
+++ b/examples/basic_inline.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>&lt;juicy-html&gt; basic inline partial</title>
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="stylesheet" href="//juicy.github.io/juicy-tile-list/examples/github-markdown.css">
     <link rel="import" href="../juicy-html.html">
     <style>
@@ -15,8 +15,8 @@
     </style>
 </head>
 <body class="markdown-body">
-    <template is="juicy-html" href="<h1>Hello World!</h1> <p>I'm <strong>inline</strong> content.</p>"></template>
+    <juicy-html html="<h1>Hello World!</h1> <p>I'm <strong>inline</strong> content.</p>"></juicy-html>
     <h2>code</h2>
-    <pre><code>&lt;template is="juicy-html" href="&lt;h1&gt;Hello World!&lt;/h1&gt; &lt;p&gt;I'm &lt;strong&gt;inline&lt;/strong&gt; content.&lt;/p&gt;"&gt;&lt;/template&gt;</code></pre>
+    <pre><code>&lt;juicy-html html="&lt;h1&gt;Hello World!&lt;/h1&gt; &lt;p&gt;I'm &lt;strong&gt;inline&lt;/strong&gt; content.&lt;/p&gt;"&gt;&lt;/juicy-html&gt;</code></pre>
 </body>
 </html>

--- a/examples/components/my-app.html
+++ b/examples/components/my-app.html
@@ -18,7 +18,7 @@
                 width: 300px;
             }
         </style>
-        <template is="juicy-html" href="{{viewmodel.html}}" model="{{viewmodel}}" on-stamped="stamped"></template>
+        <juicy-html href="{{viewmodel.html}}" model="{{viewmodel}}" on-stamped="stamped"></juicy-html>
     </template>
 </dom-module>
 <script>

--- a/examples/inline_markup_w_model_binding.html
+++ b/examples/inline_markup_w_model_binding.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>&lt;juicy-html&gt; basic inline partial</title>
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="stylesheet" href="//juicy.github.io/juicy-tile-list/examples/github-markdown.css">
 
     <link rel="import" href="../juicy-html.html">
@@ -18,11 +18,13 @@
     </style>
 </head>
 <body class="markdown-body">
-    <template is="juicy-html" content='
+    <juicy-html html='
         All those nodes will get <code>.model</code> property with object given in model attribute.
-        <template is="dom-bind">
-            <p>which can be used by <span>{{model.polymer}}</span></p>
-        </template>
+        <dom-bind>
+            <template>
+                <p>which can be used by <span>{{model.polymer}}</span></p>
+            </template>
+        </dom-bind>
         <div></div>
         <script>
             var script = (document._currentScript || document.currentScript);
@@ -35,13 +37,15 @@
             "polymer": "Polymer&apos;s dom-bind",
             "vanilla": "as well as by native JS <code>&amp;lt;script&amp;gt;</code> or custom elements"
         }'>
-    </template>
+    </juicy-html>
     <h2>Code</h2>
-    <pre><code>&lt;template is="juicy-html" content='
+    <pre><code>&lt;juicy-html html='
     All those nodes will get &lt;code&gt;.model&lt;/code&gt; property with object given in model attribute.
-    &lt;template is="dom-bind"&gt;
-      &lt;p&gt;which can be used by &lt;span&gt;{{model.polymer}}&lt;/span&gt;&lt;/p&gt;
-    &lt;/template&gt;
+    &lt;dom-bind&gt;
+      &lt;template is="dom-bind"&gt;
+        &lt;p&gt;which can be used by &lt;span&gt;{{model.polymer}}&lt;/span&gt;&lt;/p&gt;
+      &lt;/template&gt;
+    &lt;/dom-bind&gt;
     &lt;div&gt;&lt;/div&gt;
     &lt;script&gt;
       var script = (document._currentScript || document.currentScript);
@@ -53,6 +57,6 @@
     "polymer": "Polymer&apos;s dom-bind",
     "vanilla": "as well as by native JS &lt;code&gt;&amp;amp;lt;script&amp;amp;gt;&lt;/code&gt; or custom elements"
   }'>
-&lt;/template></code></pre>
+&lt;/juicy-html&gt;</code></pre>
 </body>
 </html>

--- a/examples/partials/page_1.html
+++ b/examples/partials/page_1.html
@@ -1,9 +1,11 @@
-<template is="dom-bind">
-    <h1>Hello <span>{{model.username}}</span></h1>
-</template>
+<dom-bind>
+    <template is="dom-bind">
+        <h1>Hello <span>{{model.username}}</span></h1>
+    </template>
+</dom-bind>
 <p>
     This is the Page 1.
-    <button onclick="document.getElementById('test').set('model.subpage.html', './partials/page_2.html')">Press here</button>
+    <button onclick="(Polymer.Element ? document.getElementById('test').parentNode : document.getElementById('test')).set('model.subpage.html', './partials/page_2.html')">Press here</button>
     to replace the template with Page 2
 </p>
 

--- a/examples/partials/page_2.html
+++ b/examples/partials/page_2.html
@@ -1,5 +1,5 @@
 <h1>This is Page 2</h1>
 
-<button onclick="document.getElementById('test').set('model.subpage.html', './partials/page_1.html')">
+<button onclick="(Polymer.Element ? document.getElementById('test').parentNode : document.getElementById('test')).set('model.subpage.html', './partials/page_1.html')">
     Return to Page 1
 </button>

--- a/examples/polymer_partial.html
+++ b/examples/polymer_partial.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>&lt;juicy-html&gt; in a Polymer element</title>
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="components/my-app.html">
 </head>
 <body>

--- a/examples/polymer_template_inline.html
+++ b/examples/polymer_template_inline.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>&lt;juicy-html&gt; Fancy inline partial within Polymer's dom-bind</title>
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="stylesheet" href="//juicy.github.io/juicy-tile-list/examples/github-markdown.css">
 
     <link rel="import" href="../juicy-html.html">
@@ -23,13 +23,15 @@
     </style>
 </head>
 <body class="markdown-body">
-    <template id="test" is="dom-bind">
+    <dom-bind>
+      <template is="dom-bind" id="test">
         <h1>Fancy inline partial within Polymer's dom-bind</h1>
-        <template is="juicy-html" href="{{model.subpage.Html}}" model="{{model.subpage}}">
-        </template>
+        <juicy-html html="{{model.subpage.Html}}" model="{{model.subpage}}">
+        </juicy-html>
         <h3>Code (live)</h3>
         <textarea value="{{model.subpage.Html::input}}"></textarea>
-    </template>
+      </template>
+    </dom-bind>
 
     <script>
         var model = {
@@ -38,9 +40,11 @@
                 polymer: "Polymer's dom-bind",
                 vanilla: "as well as by native JS <code>&lt;script&gt;</code> or custom elements",
                 Html: "All those nodes will get <code>.model</code> property with object given in model attribute.\n" +
-                  "<template is=\"dom-bind\">\n" +
-                  "    <p> which can be used by <span>{{model.polymer}}</span></p>\n" +
-                  "</template>\n" +
+                  "<dom-bind>\n" +
+                  "    <template is=\"dom-bind\">\n" +
+                  "        <p> which can be used by <span>{{model.polymer}}</span></p>\n" +
+                  "    </template>\n" +
+                  "</dom-bind>\n" +
                   "<div></div>\n" +
                   "<script>\n" +
                   "    var script = document._currentScript || document.currentScript;" +
@@ -50,8 +54,8 @@
                   "script>"
             }
         };
-
-        document.getElementById('test').model = model;
+        document.getElementById('test').model = model; // Polymer 1.x
+        document.getElementById('test').parentNode.model = model; // Polymer 2.0
     </script>
 </body>
 </html>

--- a/examples/polymer_template_partial.html
+++ b/examples/polymer_template_partial.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>&lt;juicy-html&gt; in a &lt;template&gt; with HTML partial loaded from a file</title>
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <link rel="import" href="../juicy-html.html">
     <link rel="import" href="../../polymer/polymer.html">
@@ -16,9 +16,11 @@
     </style>
 </head>
 <body>
-    <template id="test" is="dom-bind">
-        <template model="{{model.subpage}}" is="juicy-html" href="{{model.subpage.html}}"></template>
-    </template>
+    <dom-bind>
+        <template id="test" is="dom-bind">
+            <juicy-html model="{{model.subpage}}" href="{{model.subpage.html}}"></juicy-html>
+        </template>
+    </dom-bind>
     <script>
         var model = {
             subpage: {
@@ -26,7 +28,14 @@
                 html: "./partials/page_1.html"
             }
         };
-        document.getElementById('test').model = model;
+
+      window.addEventListener('WebComponentsReady', function() {
+          if(Polymer.Element){
+              document.getElementById('test').parentNode.model = model;
+          } else {
+              document.getElementById('test').model = model;
+          }
+      });
     </script>
 </body>
 </html>

--- a/examples/template_partial_sibling.html
+++ b/examples/template_partial_sibling.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>&lt;juicy-html&gt; in a &lt;template&gt; with HTML partial loaded as a sibling</title>
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="stylesheet" href="//juicy.github.io/juicy-tile-list/examples/github-markdown.css">
 
     <link rel="import" href="../juicy-html.html">
@@ -19,7 +19,7 @@
     <h2>Hey! those are siblings:</h2>
     <ul>
         <li class="specialExternal">Just plain <code>&lt;li&gt;</code></li>
-        <template is="juicy-html" href="./partials/page_4.html"></template>
+        <juicy-html href="./partials/page_4.html"></juicy-html>
     </ul>
 </body>
 </html>

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -6,7 +6,7 @@ https://github.com/Juicy/juicy-html
 version: 2.0.2
 -->
 <script>
-    (function () {
+    (function() {
         /**
          * Throw a warning to the console about deprecated content attribute
          * @param  {JuicyHTMLElement} element reference to the element
@@ -38,8 +38,8 @@ version: 2.0.2
             }
         }
         /**
-        * Checks whether a value is null or undefined
-        */
+         * Checks whether a value is null or undefined
+         */
         function nullOrUndefined(v) {
             return v === null || v === undefined;
         }
@@ -47,48 +47,47 @@ version: 2.0.2
         var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
 
         class JuicyHTMLElement extends HTMLElement {
-            static get observedAttributes() {return ['model', 'href', 'html', 'content']; }
-            constructor(self){
+            static get observedAttributes() {
+                return ['model', 'href', 'html', 'content'];
+            }
+            constructor(self) {
                 self = super(self);
                 var model = null; // XXX(tomalec): || this.model ? // to consider for https://github.com/Juicy/juicy-html/issues/30
                 Object.defineProperties(this, {
                     'model': {
-                        set: function (newValue) {
+                        set: function(newValue) {
                             model = newValue;
                             this.attachModel(newValue);
                         },
-                        get: function () {
+                        get: function() {
                             return model;
-                        }
-                    },
-                    'href': {
-                        set: function (newValue) {
-                            if (nullOrUndefined(newValue)) {
-                                this.removeAttribute('href');
-                            } else {
-                                this.setAttribute('href', newValue);
-                            }
-                        },
-                        get: function () {
-                            return this.getAttribute('href');
-                        }
-                    },
-                    'html': {
-                        set: function (newValue) {
-                            if (nullOrUndefined(newValue)) {
-                                this.removeAttribute('html');
-                            } else {
-                                this.setAttribute('html', newValue);
-                            }
-                        },
-                        get: function () {
-                            return this.getAttribute('html');
                         }
                     }
                 });
             }
+            // Attributes reflection
+            get href() {
+                return this.getAttribute('href');
+            }
+            set href(newValue) {
+                if (nullOrUndefined(newValue)) {
+                    this.removeAttribute('href');
+                } else {
+                    this.setAttribute('href', newValue);
+                }
+            }
+            get html() {
+                return this.getAttribute('html');
+            }
+            set html(newValue) {
+                if (nullOrUndefined(newValue)) {
+                    this.removeAttribute('html');
+                } else {
+                    this.setAttribute('html', newValue);
+                }
+            }
             /** Autostamp on connected */
-            connectedCallback(){
+            connectedCallback() {
                 this.isAttached = true;
                 // Workaround for lack of inertness as for `<tempalte is="juicy-html">`.
                 // Bellow is cheaper and simmpler than attaching shadow with display none
@@ -101,139 +100,140 @@ version: 2.0.2
                 // translate legacy `content` attribute
                 this.hasAttribute('content') && this.attributeChangedCallback('content', null, this.getAttribute('content'));
             }
-            disconnectedCallback(){
+            disconnectedCallback() {
                 this.isAttached = false;
                 this.clear();
             }
+            /**
+             * Skips/disregards pending request if any.
+             */
+            skipStampingPendingFile() {
+                if (this.pending) {
+                    this.pending.onload = null;
+                }
+            }
+            /**
+             * Load the partial from the HTTP server/cache, via XHR.
+             * @param  {String} url relative/absolute string to load the resource
+             */
+            _loadExternalFile(url) {
+                var oReq = new XMLHttpRequest();
+                var that = this;
+                this.pending = oReq;
+                oReq.onload = function(event) {
+                    that.pending = null;
+                    that.reattachTemplate_(event.target.responseText, oReq.status);
+                };
+                oReq.open("GET", url, true);
+                oReq.send();
+            }
+
+            reattachTemplate_(html, statusCode) {
+                this.clear();
+                if (html === '') {
+                    if (statusCode === 204) {
+                        console.info('no content was returned for juicy-html', this);
+                    } else {
+                        console.warn('content given for juicy-html is an empty file', this);
+                    }
+                }
+                // fragmentFromString(strHTML) from http://stackoverflow.com/a/25214113/868184
+                var range = document.createRange();
+
+                // Safari does not support `createContextualFragment` without selecting a node.
+                if (isSafari) {
+                    range.selectNode(this);
+                }
+
+                var fragment = range.createContextualFragment(html);
+                // convert dynamic NodeList to regullar array
+                this.stampedNodes = Array.prototype.slice.call(fragment.childNodes);
+                // attach models
+                this.attributeChangedCallback("model", undefined, this.model || this.getAttribute("model"));
+                this.parentNode.insertBefore(fragment, this.nextSibling);
+                this.dispatchEvent(new CustomEvent("stamped", {
+                    detail: this.stampedNodes
+                }));
+
+            }
+
+            /**
+             * Remove stamped content.
+             */
+            clear() {
+                var parent = this.parentNode;
+                var childNo = this.stampedNodes && this.stampedNodes.length || 0;
+                var child;
+                while (childNo--) {
+                    // this.stampedNodes[childNo].remove();
+                    child = this.stampedNodes[childNo];
+                    if (child.parentNode) {
+                        child.parentNode.removeChild(child);
+                    }
+                }
+                // forget the removed nodes
+                this.stampedNodes = null;
+            }
+
+            attributeChangedCallback(name, oldVal, newVal) {
+                if (this.isAttached) {
+                    switch (name) {
+                        case "model":
+                            if (typeof newVal === "string") {
+                                newVal = newVal ? JSON.parse(newVal) : null;
+                            }
+                            this.model = newVal;
+                            break;
+                        case "content":
+                            warnAboutDeprecatedContentOn(this);
+                            forwardContentValue(this, newVal);
+                            break;
+                        case "href":
+                            // skip pending request
+                            this.skipStampingPendingFile();
+                            if (newVal !== null) {
+                                this.removeAttribute('html');
+                                this._loadExternalFile(newVal);
+                            } else {
+                                this.clear();
+                            }
+                            break;
+                        case "html":
+                            if (newVal !== null) {
+                                this.removeAttribute('href');
+                                this.reattachTemplate_(newVal);
+                            } else {
+                                this.clear();
+                            }
+                            break;
+                    }
+                }
+            }
+
+            attachModel(model, arrayOfElements) {
+                arrayOfElements || (arrayOfElements = this.stampedNodes);
+                if (model === null || !arrayOfElements) {
+                    return;
+                }
+                for (var childNo = 0; childNo < arrayOfElements.length; childNo++) {
+                    arrayOfElements[childNo].model = model;
+                }
+            }
         };
-        var JuicyHTMLPrototype = JuicyHTMLElement.prototype;
-        /**
-        * @type {Boolean}
-        */
-        JuicyHTMLPrototype.isAttached = false;
         /**
          * Reference to pending request
          * @type {XMLHttpRequest}
          */
-        JuicyHTMLPrototype.pending = null;
-
-        JuicyHTMLPrototype.stampedNodes = null;
+        JuicyHTMLElement.prototype.pending = null;
         /**
-         * Skips/disregards pending request if any.
+         * Array of stamped nodes
+         * @type {Array}
          */
-        JuicyHTMLPrototype.skipStampingPendingFile = function () {
-            if (this.pending) {
-                this.pending.onload = null;
-            }
-        };
+        JuicyHTMLElement.prototype.stampedNodes = null;
         /**
-         * Load the partial from the HTTP server/cache, via XHR.
-         * @param  {String} url relative/absolute string to load the resource
-         * @return {HTMLElement}     itself
+         * @type {Boolean}
          */
-        JuicyHTMLPrototype._loadExternalFile = function (url) {
-            var oReq = new XMLHttpRequest();
-            var that = this;
-            this.pending = oReq;
-            oReq.onload = function (event) {
-                that.pending = null;
-                that.reattachTemplate_(event.target.responseText, oReq.status);
-            };
-            oReq.open("GET", url, true);
-            oReq.send();
-        };
-
-        JuicyHTMLPrototype.reattachTemplate_ = function (html, statusCode) {
-            this.clear();
-            if (html === '') {
-                if (statusCode === 204) {
-                    console.info('no content was returned for juicy-html', this);
-                } else {
-                    console.warn('content given for juicy-html is an empty file', this);
-                }
-            }
-            // fragmentFromString(strHTML) from http://stackoverflow.com/a/25214113/868184
-            var range = document.createRange();
-
-            // Safari does not support `createContextualFragment` without selecting a node.
-            if (isSafari) {
-                range.selectNode(this);
-            }
-
-            var fragment = range.createContextualFragment(html);
-            // convert dynamic NodeList to regullar array
-            this.stampedNodes = Array.prototype.slice.call(fragment.childNodes);
-            // attach models
-            this.attributeChangedCallback("model", undefined, this.model || this.getAttribute("model"));
-            this.parentNode.insertBefore(fragment, this.nextSibling);
-            this.dispatchEvent(new CustomEvent("stamped", {
-                detail: this.stampedNodes
-            }));
-
-        };
-
-        /**
-         * Remove stamped content.
-         */
-        JuicyHTMLPrototype.clear = function () {
-            var parent = this.parentNode;
-            var childNo = this.stampedNodes && this.stampedNodes.length || 0;
-            var child;
-            while (childNo--) {
-                // this.stampedNodes[childNo].remove();
-                child = this.stampedNodes[childNo];
-                if (child.parentNode) {
-                    child.parentNode.removeChild(child);
-                }
-            }
-            // forget the removed nodes
-            this.stampedNodes = null;
-        };
-
-        JuicyHTMLPrototype.attributeChangedCallback = function (name, oldVal, newVal) {
-            if (this.isAttached) {
-                switch (name) {
-                    case "model":
-                        if (typeof newVal === "string") {
-                            newVal = newVal ? JSON.parse(newVal) : null;
-                        }
-                        this.model = newVal;
-                        break;
-                    case "content":
-                        warnAboutDeprecatedContentOn(this);
-                        forwardContentValue(this, newVal);
-                        break;
-                    case "href":
-                        // skip pending request
-                        this.skipStampingPendingFile();
-                        if (newVal !== null) {
-                            this.removeAttribute('html');
-                            this._loadExternalFile(newVal);
-                        } else {
-                            this.clear();
-                        }
-                        break;
-                    case "html":
-                        if (newVal !== null) {
-                            this.removeAttribute('href');
-                            this.reattachTemplate_(newVal);
-                        } else {
-                            this.clear();
-                        }
-                        break;
-                }
-            }
-        };
-
-        JuicyHTMLPrototype.attachModel = function (model, arrayOfElements) {
-            arrayOfElements || (arrayOfElements = this.stampedNodes);
-            if (model === null || !arrayOfElements) {
-                return;
-            }
-            for (var childNo = 0; childNo < arrayOfElements.length; childNo++) {
-                arrayOfElements[childNo].model = model;
-            }
-        };
+        JuicyHTMLElement.prototype.isAttached = false;
 
         customElements.define('juicy-html', JuicyHTMLElement);
     })();

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -6,7 +6,7 @@ https://github.com/Juicy/juicy-html
 version: 2.0.2
 -->
 <script>
-    (function (scope) {
+    (function () {
         /**
          * Throw a warning to the console about deprecated content attribute
          * @param  {JuicyHTMLElement} element reference to the element
@@ -44,47 +44,73 @@ version: 2.0.2
             return v === null || v === undefined;
         }
 
-        var JuicyHTMLPrototype = Object.create((HTMLTemplateElement || HTMLElement).prototype);
         var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
 
-        JuicyHTMLPrototype.createdCallback = function () {
-            var model = null; // XXX(tomalec): || this.model ? // to consider for https://github.com/Juicy/juicy-html/issues/30
-            Object.defineProperties(this, {
-                'model': {
-                    set: function (newValue) {
-                        model = newValue;
-                        this.attachModel(newValue);
-                    },
-                    get: function () {
-                        return model;
-                    }
-                },
-                'href': {
-                    set: function (newValue) {
-                        if (nullOrUndefined(newValue)) {
-                            this.removeAttribute('href');
-                        } else {
-                            this.setAttribute('href', newValue);
+        class JuicyHTMLElement extends HTMLElement {
+            static get observedAttributes() {return ['model', 'href', 'html', 'content']; }
+            constructor(self){
+                self = super(self);
+                var model = null; // XXX(tomalec): || this.model ? // to consider for https://github.com/Juicy/juicy-html/issues/30
+                Object.defineProperties(this, {
+                    'model': {
+                        set: function (newValue) {
+                            model = newValue;
+                            this.attachModel(newValue);
+                        },
+                        get: function () {
+                            return model;
                         }
                     },
-                    get: function () {
-                        return this.getAttribute('href');
-                    }
-                },
-                'html': {
-                    set: function (newValue) {
-                        if (nullOrUndefined(newValue)) {
-                            this.removeAttribute('html');
-                        } else {
-                            this.setAttribute('html', newValue);
+                    'href': {
+                        set: function (newValue) {
+                            if (nullOrUndefined(newValue)) {
+                                this.removeAttribute('href');
+                            } else {
+                                this.setAttribute('href', newValue);
+                            }
+                        },
+                        get: function () {
+                            return this.getAttribute('href');
                         }
                     },
-                    get: function () {
-                        return this.getAttribute('html');
+                    'html': {
+                        set: function (newValue) {
+                            if (nullOrUndefined(newValue)) {
+                                this.removeAttribute('html');
+                            } else {
+                                this.setAttribute('html', newValue);
+                            }
+                        },
+                        get: function () {
+                            return this.getAttribute('html');
+                        }
                     }
-                }
-            });
+                });
+            }
+            /** Autostamp on connected */
+            connectedCallback(){
+                this.isAttached = true;
+                // Workaround for lack of inertness as for `<tempalte is="juicy-html">`.
+                // Bellow is cheaper and simmpler than attaching shadow with display none
+                // it does not give exactly the same behavior, but hopefully nobody would like to make it block.
+                this.style.display = 'none';
+                // autostamp
+                // TODO(tomalec): read pre-upgrade properties in cheap manner
+                this.hasAttribute('href') && this.attributeChangedCallback('href', null, this.getAttribute('href'));
+                this.hasAttribute('html') && this.attributeChangedCallback('html', null, this.getAttribute('html'));
+                // translate legacy `content` attribute
+                this.hasAttribute('content') && this.attributeChangedCallback('content', null, this.getAttribute('content'));
+            }
+            disconnectedCallback(){
+                this.isAttached = false;
+                this.clear();
+            }
         };
+        var JuicyHTMLPrototype = JuicyHTMLElement.prototype;
+        /**
+        * @type {Boolean}
+        */
+        JuicyHTMLPrototype.isAttached = false;
         /**
          * Reference to pending request
          * @type {XMLHttpRequest}
@@ -164,20 +190,6 @@ version: 2.0.2
             this.stampedNodes = null;
         };
 
-        JuicyHTMLPrototype.isAttached = false;
-        JuicyHTMLPrototype.attachedCallback = function () {
-            this.isAttached = true;
-            // autostamp
-            // TODO(tomalec): read pre-upgrade properties in cheap manner
-            this.hasAttribute('href') && this.attributeChangedCallback('href', null, this.getAttribute('href'));
-            this.hasAttribute('html') && this.attributeChangedCallback('html', null, this.getAttribute('html'));
-            // translate legacy `content` attribute
-            this.hasAttribute('content') && this.attributeChangedCallback('content', null, this.getAttribute('content'));
-        };
-        JuicyHTMLPrototype.detachedCallback = function () {
-            this.isAttached = false;
-            this.clear();
-        };
         JuicyHTMLPrototype.attributeChangedCallback = function (name, oldVal, newVal) {
             if (this.isAttached) {
                 switch (name) {
@@ -223,9 +235,6 @@ version: 2.0.2
             }
         };
 
-        scope.JuicyHTMLElement = document.registerElement('juicy-html', {
-            prototype: JuicyHTMLPrototype,
-            extends: "template"
-        });
-    })(window);
+        customElements.define('juicy-html', JuicyHTMLElement);
+    })();
 </script>

--- a/test/content-legacy/deprecation-warning.html
+++ b/test/content-legacy/deprecation-warning.html
@@ -17,15 +17,13 @@
     <test-fixture id="juicy-html-with-content">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" content="../mock/smth.html">
-            </template></div>
+            <div><juicy-html content="../mock/smth.html"></juicy-html></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-without-content">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html">
-            </template></div>
+            <div><juicy-html></juicy-html></div>
         </template>
     </test-fixture>
 
@@ -47,7 +45,7 @@
             });
             context('when element is attached with content attribute', function () {
                 beforeEach(function (done) {
-                    myEl = fixture('juicy-html-with-content').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-with-content').querySelector('juicy-html');
                     // wait for (faked) XHR
                     setTimeout(done, 100);
                 });
@@ -59,7 +57,7 @@
             });
             context('when content attribute is changed', function () {
                 beforeEach(function (done) {
-                    myEl = fixture('juicy-html-without-content').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-without-content').querySelector('juicy-html');
                     myEl.setAttribute('content', '../mock/smth.html');
                     // wait for (faked) XHR
                     setTimeout(done, 100);

--- a/test/content-legacy/inline.html
+++ b/test/content-legacy/inline.html
@@ -18,8 +18,7 @@
     <test-fixture id="juicy-html-fixture">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" content="<h1>Hello World</h1>">
-            </template></div>
+            <div><juicy-html content="<h1>Hello World</h1>"></juicy-html></div>
         </template>
     </test-fixture>
 
@@ -28,7 +27,7 @@
             var myEl;
             context('when created with HTML markup in content attribute', function() {
                 beforeEach(function() {
-                    myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
                 });
                 it('should stamp it into DOM as a sibling', function(){
                     expect(myEl.nextElementSibling).to.be.not.null;

--- a/test/content-legacy/no-content.html
+++ b/test/content-legacy/no-content.html
@@ -17,22 +17,19 @@
     <test-fixture id="juicy-html-with-content">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" content="../mock/smth.html">
-            </template></div>
+            <div><juicy-html content="../mock/smth.html"></juicy-html></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-204-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" content="../mock/204">
-            </template></div>
+            <div><juicy-html content="../mock/204"></juicy-html></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-200-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" content="../mock/200">
-            </template></div>
+            <div><juicy-html content="../mock/200"></juicy-html></div>
         </template>
     </test-fixture>
 
@@ -67,8 +64,8 @@
             context('when external file returns <code>204 No Content</code>', function () {
                 beforeEach(function (done) {
 
-                    myEl = fixture('juicy-html-204-empty').querySelector('template[is="juicy-html"]');
-                    changedEl = fixture('juicy-html-with-content').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-204-empty').querySelector('juicy-html');
+                    changedEl = fixture('juicy-html-with-content').querySelector('juicy-html');
                     changedEl.setAttribute('content', '../mock/204');
                     // wait for (faked) XHR
                     setTimeout(done, 300);
@@ -89,8 +86,8 @@
             });
             context('when external file returns <code>200 Ok</code> but no content', function () {
                 beforeEach(function (done) {
-                    myEl = fixture('juicy-html-200-empty').querySelector('template[is="juicy-html"]');
-                    changedEl = fixture('juicy-html-with-content').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-200-empty').querySelector('juicy-html');
+                    changedEl = fixture('juicy-html-with-content').querySelector('juicy-html');
                     changedEl.setAttribute('content', '../mock/200');
                     // wait for (faked) XHR
                     setTimeout(done, 300);

--- a/test/content-legacy/skipping.html
+++ b/test/content-legacy/skipping.html
@@ -18,8 +18,7 @@
     <test-fixture id="juicy-html-fixture">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html">
-            </template></div>
+            <div><juicy-html></juicy-html></div>
         </template>
     </test-fixture>
 
@@ -28,7 +27,7 @@
             var myEl;
             context('when skipStampingPendingFile method is called after request for file was send but before it responded', function() {
                 beforeEach(function() {
-                    myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
                     myEl.setAttribute('content', '../../partials/basic.html');
                     myEl.skipStampingPendingFile();
                 });
@@ -42,7 +41,7 @@
             });
             context('when content property is changed', function() {
                 beforeEach(function() {
-                    myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
                     myEl.setAttribute('content', '../../partials/basic.html');
                     sinon.spy(myEl, 'skipStampingPendingFile');
                 });

--- a/test/content-legacy/skipping.html
+++ b/test/content-legacy/skipping.html
@@ -28,7 +28,7 @@
             context('when skipStampingPendingFile method is called after request for file was send but before it responded', function() {
                 beforeEach(function() {
                     myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
-                    myEl.setAttribute('content', '../../partials/basic.html');
+                    myEl.setAttribute('content', '../../examples/partials/basic.html');
                     myEl.skipStampingPendingFile();
                 });
                 it('should NOT stamp anything', function(done){
@@ -42,14 +42,14 @@
             context('when content property is changed', function() {
                 beforeEach(function() {
                     myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
-                    myEl.setAttribute('content', '../../partials/basic.html');
+                    myEl.setAttribute('content', '../../examples/partials/basic.html');
                     sinon.spy(myEl, 'skipStampingPendingFile');
                 });
                 it('to another url, skipStampingPendingFile method should get called', function(){
                     // pre-test conditions
                     expect(myEl.skipStampingPendingFile).not.to.be.called;
                     // actual test
-                    myEl.setAttribute('content', '../../partials/page_1.html');
+                    myEl.setAttribute('content', '../../examples/partials/page_1.html');
                     expect(myEl.skipStampingPendingFile).to.be.calledOnce;
                 });
                 it('to a string, skipStampingPendingFile method should get called', function(){

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
 

--- a/test/inline.html
+++ b/test/inline.html
@@ -18,8 +18,7 @@
     <test-fixture id="juicy-html-fixture">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" html="<h1>Hello World</h1>">
-            </template></div>
+            <div><juicy-html html="<h1>Hello World</h1>"></juicy-html></div>
         </template>
     </test-fixture>
 
@@ -28,7 +27,7 @@
             var myEl;
             context('when created with HTML markup in html attribute', function() {
                 beforeEach(function(done) {
-                    myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
                     // wait for polyfilled callbacks
                     setTimeout(done, 10);
                 });

--- a/test/no-content.html
+++ b/test/no-content.html
@@ -17,7 +17,7 @@
     <test-fixture id="juicy-html-with-href">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><juicy-html href="./mock/smth"></juicy-html></div>
+            <div><juicy-html href="./mock/smth.html"></juicy-html></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-204-empty">

--- a/test/no-content.html
+++ b/test/no-content.html
@@ -17,22 +17,19 @@
     <test-fixture id="juicy-html-with-href">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="./mock/smth">
-            </template></div>
+            <div><juicy-html href="./mock/smth"></juicy-html></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-204-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="./mock/204">
-            </template></div>
+            <div><juicy-html href="./mock/204"></juicy-html></div>
         </template>
     </test-fixture>
     <test-fixture id="juicy-html-200-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html" href="./mock/200">
-            </template></div>
+            <div><juicy-html href="./mock/200"></juicy-html></div>
         </template>
     </test-fixture>
 
@@ -68,8 +65,8 @@
             context('when external file returns <code>204 No Content</code>', function () {
                 beforeEach(function (done) {
 
-                    myEl = fixture('juicy-html-204-empty').querySelector('template[is="juicy-html"]');
-                    changedEl = fixture('juicy-html-with-href').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-204-empty').querySelector('juicy-html');
+                    changedEl = fixture('juicy-html-with-href').querySelector('juicy-html');
                     changedEl.setAttribute('href', './mock/204');
                     // wait for (faked) XHR
                     setTimeout(done, 300);
@@ -90,8 +87,8 @@
             });
             context('when external file returns <code>200 Ok</code> but no content', function () {
                 beforeEach(function (done) {
-                    myEl = fixture('juicy-html-200-empty').querySelector('template[is="juicy-html"]');
-                    changedEl = fixture('juicy-html-with-href').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-200-empty').querySelector('juicy-html');
+                    changedEl = fixture('juicy-html-with-href').querySelector('juicy-html');
                     changedEl.setAttribute('href', './mock/200');
                     // wait for (faked) XHR
                     setTimeout(done, 300);

--- a/test/skipping.html
+++ b/test/skipping.html
@@ -18,8 +18,7 @@
     <test-fixture id="juicy-html-fixture">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><template is="juicy-html">
-            </template></div>
+            <div><juicy-html></juicy-html></div>
         </template>
     </test-fixture>
 
@@ -27,7 +26,7 @@
         describe('<juicy-html> after request for file was send but before it responded', function() {
             var myEl;
             beforeEach(function() {
-                myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
+                myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
                 myEl.setAttribute('href', '../examples/partials/basic.html');
                 sinon.spy(myEl, 'skipStampingPendingFile');
             });
@@ -88,7 +87,7 @@
             });
             describe("Undefined URL", function() {
                 it("It shouldn't issue a request if URL is undefined", function() {
-                    myEl = fixture('juicy-html-fixture').querySelector('template[is="juicy-html"]');
+                    myEl = fixture('juicy-html-fixture').querySelector('juicy-html');
                     sinon.spy(myEl, '_loadExternalFile');
                     myEl.href = undefined;
                     expect(myEl._loadExternalFile).not.to.be.called;


### PR DESCRIPTION
fixes: https://github.com/Juicy/juicy-html/issues/27

Please note that I'm "hiding" an element with inline styles, not to tie the dependency for Shadow DOM, and not to create an overhead of shadow root + style tag *2 versions. I hope that would be enough, at least until we will have something new from W3C for extending `<tempalte>` element or to use inertness of it.

BTW, that's what Polymer's `<dom-bind>` does.