### PR TITLE
Use mocked AJAX to avoid network stack + polyserve delays in tests

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -17,7 +17,6 @@
           'inline.html',
           'no-content.html',
           'skipping.html'
-
         ]);
     </script>
 </body>

--- a/test/mock/smth.html
+++ b/test/mock/smth.html
@@ -1,1 +1,0 @@
-<div id="smth">smth</div></template>

--- a/test/no-content.html
+++ b/test/no-content.html
@@ -36,7 +36,8 @@
     </test-fixture>
 
     <script>
-        describe('when external file returns <code>204 No Content</code>', function () {
+        describe('<juicy-html>', function () {
+
             var myEl, changedEl, server, infoSpy, warnSpy, errorSpy;
             beforeEach(function () {
                 infoSpy = sinon.spy(console, 'info');
@@ -62,7 +63,7 @@
             after(function () {
                 server.restore();
             });
-            
+
             context('when external file returns <code>204 No Content</code>', function () {
                 beforeEach(function (done) {
 
@@ -87,9 +88,9 @@
 
             });
 
-            context('when external file returns <code>200 Ok</code> but no content', function () {                
+            context('when external file returns <code>200 Ok</code> but no content', function () {
                 beforeEach(function (done) {
-                    
+
                     myEl = fixture('juicy-html-200-empty').querySelector('juicy-html');
                     changedEl = fixture('juicy-html-with-href').querySelector('juicy-html');
 
@@ -97,7 +98,7 @@
                     // wait for (faked) XHR
                     setTimeout(done, 20);
                 });
-                
+
                 it('should not throw any error', function () {
                     expect(errorSpy).not.to.be.called;
                 });

--- a/test/no-content.html
+++ b/test/no-content.html
@@ -29,12 +29,14 @@
     <test-fixture id="juicy-html-200-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div><juicy-html href="./mock/200"></juicy-html></div>
+            <div>
+                <juicy-html href="./mock/200"></juicy-html>
+            </div>
         </template>
     </test-fixture>
 
     <script>
-        describe('<juicy-html>', function () {
+        describe('when external file returns <code>204 No Content</code>', function () {
             var myEl, changedEl, server, infoSpy, warnSpy, errorSpy;
             beforeEach(function () {
                 infoSpy = sinon.spy(console, 'info');
@@ -51,17 +53,16 @@
             });
             before(function () {
                 server = sinon.fakeServer.create();
-                server.xhr.useFilters = true;
-                server.xhr.addFilter(function (method, url) {
-                    //whenever this returns true the request will not faked
-                    return !url.match(/\.\/mock\/204/);
-                });
                 server.respondWith('GET', './mock/204', [204, {"Content-Type": "text/html"}, '']);
+                server.respondWith('GET', './mock/smth.html', [200, {"Content-Type": "text/html"}, '<div id="smth">smth</div></template>']);
+                server.respondWith('GET', './mock/200', [200, { "Content-Type": "text/html" }, '']);
                 server.autoRespond = true;
+                server.autoRespondAfter = 5;
             });
             after(function () {
                 server.restore();
             });
+            
             context('when external file returns <code>204 No Content</code>', function () {
                 beforeEach(function (done) {
 
@@ -69,7 +70,7 @@
                     changedEl = fixture('juicy-html-with-href').querySelector('juicy-html');
                     changedEl.setAttribute('href', './mock/204');
                     // wait for (faked) XHR
-                    setTimeout(done, 300);
+                    setTimeout(done, 20);
                 });
                 it('should not throw any error', function () {
                     expect(errorSpy).not.to.be.called;
@@ -85,14 +86,18 @@
                 });
 
             });
-            context('when external file returns <code>200 Ok</code> but no content', function () {
+
+            context('when external file returns <code>200 Ok</code> but no content', function () {                
                 beforeEach(function (done) {
+                    
                     myEl = fixture('juicy-html-200-empty').querySelector('juicy-html');
                     changedEl = fixture('juicy-html-with-href').querySelector('juicy-html');
+
                     changedEl.setAttribute('href', './mock/200');
                     // wait for (faked) XHR
-                    setTimeout(done, 300);
+                    setTimeout(done, 20);
                 });
+                
                 it('should not throw any error', function () {
                     expect(errorSpy).not.to.be.called;
                 });
@@ -101,14 +106,15 @@
                     expect(changedEl.nextElementSibling).to.be.null;
                     expect(changedEl.previousElementSibling).to.be.null;
                 });
+
                 it('should call <code>console.warn</code>', function () {
                     expect(warnSpy).to.be.called;
                     expect(warnSpy).to.be.calledTwice; // once per element
                 });
-
             });
-        });
-    </script>
+});
+
+       </script>
 
 </body>
 

--- a/test/no-content.html
+++ b/test/no-content.html
@@ -29,9 +29,7 @@
     <test-fixture id="juicy-html-200-empty">
         <template>
             <!-- nest to workaround test-fixture bug -->
-            <div>
-                <juicy-html href="./mock/200"></juicy-html>
-            </div>
+            <div><juicy-html href="./mock/200"></juicy-html></div>
         </template>
     </test-fixture>
 

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,24 +1,28 @@
 {
-    "verbose": false,
-    "plugins": {
-        "local": {
-            "browsers": ["chrome", "firefox"]
+  "verbose": false,
+  "plugins": {
+    "local": {
+      "browsers": ["chrome", "firefox"]
+    },
+    "sauce": {
+      "disabled": true,
+      "browsers": [
+        {
+          "browserName": "microsoftedge",
+          "platform": "Windows 10",
+          "version": ""
         },
-        "sauce": {
-            "disabled": true,
-            "browsers": [{
-                "browserName": "microsoftedge",
-                "platform": "Windows 10",
-                "version": ""
-            }, {
-                "browserName": "internet explorer",
-                "platform": "Windows 8.1",
-                "version": "11"
-            }, {
-                "browserName": "safari",
-                "platform": "OS X 10.11",
-                "version": "10"
-            }]
+        {
+          "browserName": "internet explorer",
+          "platform": "Windows 8.1",
+          "version": "11"
+        },
+        {
+          "browserName": "safari",
+          "platform": "OS X 10.11",
+          "version": "10"
         }
+      ]
     }
+  }
 }


### PR DESCRIPTION
I gave it several shots with local Chrome and couldn't possibly come by the reason. Can we go for this?