### PR TITLE
Read & use pre-upgrade state of the html, href, model attributes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "juicy-html",
   "description": "A custom element that lets you load HTML partials into your Web page. Declarative way for client-side includes.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "homepage": "https://github.com/Juicy/juicy-html",
   "authors": [
     "Joachim Wester <joachimwester@me.com>",

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -68,11 +68,13 @@ version: 4.0.0
                 this.style.display = 'none';
                 // autostamp
                 
-                let href = this.href || this.hasAttribute('href');
-                let html = this.html || this.hasAttribute('html');
+                if (this.href || this.hasAttribute('href')) {
+                    this.attributeChangedCallback('href', null, this.href || this.getAttribute('href'));
+                }
 
-                href && this.attributeChangedCallback('href', null, href);
-                html && this.attributeChangedCallback('html', null, html);
+                if (this.html || this.hasAttribute('html')) {
+                    this.attributeChangedCallback('html', null, this.html || this.getAttribute('html'));
+                }
             }
             disconnectedCallback() {
                 this.isAttached = false;

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -22,7 +22,10 @@ version: 4.0.0
             }
             constructor(self) {
                 self = super(self);
-                var model = null; // XXX(tomalec): || this.model ? // to consider for https://github.com/Juicy/juicy-html/issues/30
+                
+                // Idea: Handle pre-upgrade state
+                // https://github.com/Juicy/juicy-html/issues/30
+                var model = null || this.model;
                 Object.defineProperties(this, {
                     'model': {
                         set: function(newValue) {
@@ -64,9 +67,12 @@ version: 4.0.0
                 // it does not give exactly the same behavior, but hopefully nobody would like to make it block.
                 this.style.display = 'none';
                 // autostamp
-                // TODO(tomalec): read pre-upgrade properties in cheap manner
-                this.hasAttribute('href') && this.attributeChangedCallback('href', null, this.getAttribute('href'));
-                this.hasAttribute('html') && this.attributeChangedCallback('html', null, this.getAttribute('html'));
+                
+                let href = this.href || this.hasAttribute('href');
+                let html = this.html || this.hasAttribute('html');
+
+                href && this.attributeChangedCallback('href', null, href);
+                html && this.attributeChangedCallback('html', null, html);
             }
             disconnectedCallback() {
                 this.isAttached = false;

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -25,7 +25,7 @@ version: 4.0.1
                 
                 // Idea: Handle pre-upgrade state
                 // https://github.com/Juicy/juicy-html/issues/30
-                var model = null || this.model;
+                var model = this.model || null;
                 Object.defineProperties(this, {
                     'model': {
                         set: function(newValue) {

--- a/juicy-html.html
+++ b/juicy-html.html
@@ -3,7 +3,7 @@ juicy-html.html
 (c) 2013-2015 Juicy
 MIT license
 https://github.com/Juicy/juicy-html
-version: 4.0.0
+version: 4.0.1
 -->
 <script>
     (function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juicy-html",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A custom element that lets you load HTML partials into your Web page. Declarative way for client-side includes.",
   "homepage": "https://github.com/Juicy/juicy-html",
   "repository": {


### PR DESCRIPTION
Related issue - [Idea: Handle pre-upgrade state #30](https://github.com/Juicy/juicy-html/issues/30).